### PR TITLE
Add .gitattributes file to ignore HTML files for language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-detectable=false


### PR DESCRIPTION
This pull request adds a .gitattributes file to the repository in order to ignore HTML files for language detection. This will prevent HTML files from being incorrectly identified as a different programming language.