### PR TITLE
Add .css file to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.html linguist-detectable=false
+*.css linguist-detectable=false


### PR DESCRIPTION
This pull request adds a .css file to the .gitattributes file. This change ensures that .css files are not detected by the linguist tool.