### PR TITLE
[BUG] : Invalid Credentials is sending OK HTTP Code #52: Fix user authentication bug Fix user authentication bug

### DIFF
--- a/src/controller/auth.ts
+++ b/src/controller/auth.ts
@@ -92,7 +92,9 @@ class AuthController {
       return next(new ErrorResponse(RESPONSE.error.INVALID_CREDENTIAL, Code.UNAUTHORIZED))
     }
 
-    AuthController._sendTokenResponse(user, Code.OK, res)
+    if (user) {
+      AuthController._sendTokenResponse(user, Code.OK, res)
+    }
   }
 
   //@desc     Get Log out User


### PR DESCRIPTION
This pull request fixes a bug where logging in with invalid credentials would result in a 200 or OK HTTP code instead of throwing an error message. The issue was caused by the `_sendTokenResponse` function being called even when the user was not found. This pull request adds a check to only call the function if the user is found.