### PR TITLE
Fix findOneAndUpdate() parameter bug in BootcampController

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tccp-server",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tccp-server",
-      "version": "1.0.3",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@types/bcryptjs": "^2.4.6",

--- a/src/controller/bootcamp.ts
+++ b/src/controller/bootcamp.ts
@@ -97,7 +97,7 @@ class BootcampController {
       return next(new ErrorResponse(RESPONSE.error[401], (res.statusCode = Code.UNAUTHORIZED)))
     }
 
-    bootcamp = await Bootcamp.findOneAndUpdate(req.params.id, req.body, {
+    bootcamp = await Bootcamp.findOneAndUpdate({ _id: req.params.id }, req.body, {
       new: true,
       runValidators: true
     })


### PR DESCRIPTION
[BUG] : Parameter "filter" to findOneAndUpdate() must be an object #56: Update package-lock.json and BootcampController to fix version and update findOneAndUpdate method

This pull request fixes the bug in the BootcampController where the parameter "filter" to the findOneAndUpdate() method was not being passed as an object. The fix updates the findOneAndUpdate() method call to pass the filter as an object by wrapping the filter value with curly braces. This ensures that the method works correctly and returns the updated entity. The package-lock.json file is also updated to fix the version. Fixes #56.